### PR TITLE
Create unit tests for config and DB

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestCreateConfig(t *testing.T) {
+	config := CreateConfig()
+	// Validate creation of basic config with defaults
+	if config == nil {
+		t.Error("Received nil object from CreateConfig()")
+	}
+
+	numDefaults := len(config.AllKeys())
+	if numDefaults == 0 {
+		t.Error("No default values found in config.")
+	}
+}

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestCreateDBHandler(t *testing.T) {
+	config := CreateConfig()
+
+	db, err := sql.Open("mysql", "/") // Using an actual sql.DB here as placeholder
+	if err != nil {
+		t.Errorf("Failed to open database: %v", err)
+	}
+
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			t.Errorf("Failed to close database: %v", err)
+		}
+	}()
+
+	dbHandler := CreateDBHandler(config, db)
+
+	if dbHandler.db != db {
+		t.Error("DBHandler.db not pointing to provided *sql.DB instance.")
+	}
+
+	if dbHandler.availableWhenDonor != config.GetBool("options.available_when_donor") {
+		t.Error("DBHandler.availableWhenDonor does not match provided config.")
+	}
+
+	if dbHandler.availableWhenReadOnly != config.GetBool("options.available_when_readonly") {
+		t.Error("DBHandler.availableWhenReadOnly does not match provided config.")
+	}
+}
+
+func TestBuildDSN(t *testing.T) {
+	config := CreateConfig()
+	dsn := BuildDSN(config)
+	defaultDSN := mysql.NewConfig().FormatDSN()
+
+	if len(dsn) == 0 {
+		t.Error("Received empty DSN from BuildDSN().")
+	}
+
+	if dsn == defaultDSN {
+		t.Error("Received blank DSN from BuildDSN().")
+	}
+}
+
+func getMockRow(val1 interface{}, val2 interface{}) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"variable", "value"}).AddRow(val1, val2)
+}
+
+func TestGetWsrepLocalState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Errorf("Failed to open sqlmock database: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare(wsrepLocalStateQuery)
+	mock.ExpectQuery(wsrepLocalStateQuery).WillReturnRows(getMockRow("wsrep_local_state", Synced))
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	wsrepStatus := dbHandler.getWsrepLocalState()
+
+	if wsrepStatus != Synced {
+		t.Errorf("Expected WsrepStatus \"Synced\" but received \"%v\".", wsrepStatus)
+	}
+}
+
+func TestOfflinegetWsrepLocalState(t *testing.T) {
+	db, err := sql.Open("mysql", "/") // Using an actual sql.DB here to simulate database being offline
+	if err != nil {
+		t.Errorf("Failed to open database: %v", err)
+	}
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	wsrepStatus := dbHandler.getWsrepLocalState()
+
+	if wsrepStatus != Joining {
+		t.Errorf("Expected WsrepStatus \"Joining\" due to server being offline but received \"%v\".", wsrepStatus)
+	}
+}
+
+func TestIsReadOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Errorf("Failed to open sqlmock database: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPrepare(readOnlyQuery)
+	mock.ExpectQuery(readOnlyQuery).WillReturnRows(getMockRow("read_only", "OFF"))
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	if dbHandler.isReadOnly() {
+		t.Error("Database is read-write but isReadOnly() returned true.")
+	}
+}
+
+func TestSyncedRWStatus(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption((true)))
+	if err != nil {
+		t.Errorf("Failed to open sqlmock database: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing()
+	mock.ExpectPrepare(wsrepLocalStateQuery)
+	mock.ExpectQuery(wsrepLocalStateQuery).WillReturnRows(getMockRow("wsrep_local_state", Synced))
+	mock.ExpectPrepare(readOnlyQuery)
+	mock.ExpectQuery(readOnlyQuery).WillReturnRows(getMockRow("read_only", "OFF"))
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	ready, msg := RunStatusCheck(dbHandler)
+
+	if !ready {
+		t.Errorf("Expected database to be available but RunStatusCheck returned false with message \"%s\".", msg)
+	}
+}
+
+func TestIsConnected(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption((true)))
+	if err != nil {
+		t.Errorf("Failed to open sqlmock database: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing()
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	if dbHandler.isConnected() {
+		t.Errorf("Expected database to be connected but isConnected() returned false.")
+	}
+}
+
+func TestDBOffline(t *testing.T) {
+	db, err := sql.Open("mysql", "/") // Using an actual sql.DB here to simulate database being offline
+	if err != nil {
+		t.Errorf("Failed to open database: %v", err)
+	}
+
+	dbHandler := &DBHandler{
+		db,
+		false,
+		false,
+	}
+
+	ready, _ := RunStatusCheck(dbHandler)
+
+	if ready {
+		t.Error("Expected database to be unavailable but RunStatusCheck returned true.")
+	}
+}

--- a/database_test.go
+++ b/database_test.go
@@ -61,7 +61,12 @@ func TestGetWsrepLocalState(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-	defer db.Close()
+
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close sqlmock database: %v", err)
+		}
+	)()
 
 	mock.ExpectPrepare(wsrepLocalStateQuery)
 	mock.ExpectQuery(wsrepLocalStateQuery).WillReturnRows(getMockRow("wsrep_local_state", Synced))
@@ -85,6 +90,12 @@ func TestOfflinegetWsrepLocalState(t *testing.T) {
 		t.Errorf("Failed to open database: %v", err)
 	}
 
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close database: %v", err)
+		}
+	)()
+
 	dbHandler := &DBHandler{
 		db,
 		false,
@@ -103,7 +114,12 @@ func TestIsReadOnly(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-	defer db.Close()
+
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close sqlmock database: %v", err)
+		}
+	)()
 
 	mock.ExpectPrepare(readOnlyQuery)
 	mock.ExpectQuery(readOnlyQuery).WillReturnRows(getMockRow("read_only", "OFF"))
@@ -124,7 +140,12 @@ func TestSyncedRWStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-	defer db.Close()
+
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close sqlmock database: %v", err)
+		}
+	)()
 
 	mock.ExpectPing()
 	mock.ExpectPrepare(wsrepLocalStateQuery)
@@ -150,7 +171,12 @@ func TestIsConnected(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-	defer db.Close()
+
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close sqlmock database: %v", err)
+		}
+	)()
 
 	mock.ExpectPing()
 
@@ -170,6 +196,12 @@ func TestDBOffline(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open database: %v", err)
 	}
+	
+	defer func{
+		err := db.Close(); if err != nil {
+			t.Logf("Failed to close database: %v", err)
+		}
+	)()
 
 	dbHandler := &DBHandler{
 		db,

--- a/database_test.go
+++ b/database_test.go
@@ -16,13 +16,6 @@ func TestCreateDBHandler(t *testing.T) {
 		t.Errorf("Failed to open database: %v", err)
 	}
 
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Errorf("Failed to close database: %v", err)
-		}
-	}()
-
 	dbHandler := CreateDBHandler(config, db)
 
 	if dbHandler.db != db {
@@ -62,12 +55,6 @@ func TestGetWsrepLocalState(t *testing.T) {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
 
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close sqlmock database: %v", err)
-		}
-	)()
-
 	mock.ExpectPrepare(wsrepLocalStateQuery)
 	mock.ExpectQuery(wsrepLocalStateQuery).WillReturnRows(getMockRow("wsrep_local_state", Synced))
 
@@ -90,12 +77,6 @@ func TestOfflinegetWsrepLocalState(t *testing.T) {
 		t.Errorf("Failed to open database: %v", err)
 	}
 
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close database: %v", err)
-		}
-	)()
-
 	dbHandler := &DBHandler{
 		db,
 		false,
@@ -114,12 +95,6 @@ func TestIsReadOnly(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close sqlmock database: %v", err)
-		}
-	)()
 
 	mock.ExpectPrepare(readOnlyQuery)
 	mock.ExpectQuery(readOnlyQuery).WillReturnRows(getMockRow("read_only", "OFF"))
@@ -140,12 +115,6 @@ func TestSyncedRWStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
-
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close sqlmock database: %v", err)
-		}
-	)()
 
 	mock.ExpectPing()
 	mock.ExpectPrepare(wsrepLocalStateQuery)
@@ -172,12 +141,6 @@ func TestIsConnected(t *testing.T) {
 		t.Errorf("Failed to open sqlmock database: %v", err)
 	}
 
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close sqlmock database: %v", err)
-		}
-	)()
-
 	mock.ExpectPing()
 
 	dbHandler := &DBHandler{
@@ -186,7 +149,7 @@ func TestIsConnected(t *testing.T) {
 		false,
 	}
 
-	if dbHandler.isConnected() {
+	if !dbHandler.isConnected() {
 		t.Errorf("Expected database to be connected but isConnected() returned false.")
 	}
 }
@@ -196,12 +159,6 @@ func TestDBOffline(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to open database: %v", err)
 	}
-	
-	defer func{
-		err := db.Close(); if err != nil {
-			t.Logf("Failed to close database: %v", err)
-		}
-	)()
 
 	dbHandler := &DBHandler{
 		db,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/danclough/mysql-healthcheck
 go 1.14
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/viper v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
+github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
Created unit tests for config and database functions.
Config functions are using a blank config populated only with defaults.
Database functions are being mocked with [go-sqlmock](https://github.com/DATA-DOG/go-sqlmock).